### PR TITLE
Fix small typos for "Mismatch" word

### DIFF
--- a/po/de.po
+++ b/po/de.po
@@ -857,7 +857,7 @@ msgid "Next match for "
 msgstr "Nächster Treffer für "
 
 #: src/libs/ui/newpassworddialog.cc:43 src/libs/ui/newpassworddialog.cc:52
-msgid "Password Missmatch"
+msgid "Password Mismatch"
 msgstr "Passwörter stimmen nicht überein"
 
 #: src/libs/ui/newpassworddialog.cc:44 src/libs/ui/newpassworddialog.cc:53

--- a/po/yapet.pot
+++ b/po/yapet.pot
@@ -850,7 +850,7 @@ msgid "Next match for "
 msgstr ""
 
 #: src/libs/ui/newpassworddialog.cc:43 src/libs/ui/newpassworddialog.cc:52
-msgid "Password Missmatch"
+msgid "Password Mismatch"
 msgstr ""
 
 #: src/libs/ui/newpassworddialog.cc:44 src/libs/ui/newpassworddialog.cc:53

--- a/src/libs/ui/newpassworddialog.cc
+++ b/src/libs/ui/newpassworddialog.cc
@@ -40,7 +40,7 @@ bool NewPasswordDialog::on_close() {
     if (!match() && dialog_state() != YACURS::DIALOG_CANCEL) {
         assert(nomatchdialog == nullptr);
         nomatchdialog = new YACURS::MessageBox2(
-            _("Password Missmatch"), _("Passwords do not match."),
+            _("Password Mismatch"), _("Passwords do not match."),
             _("Do you want to retry?"), YACURS::YESNO);
         nomatchdialog->show();
         return false;
@@ -49,7 +49,7 @@ bool NewPasswordDialog::on_close() {
     if (pwinput1->input().empty() && dialog_state() != YACURS::DIALOG_CANCEL) {
         assert(nomatchdialog == nullptr);
         nomatchdialog = new YACURS::MessageBox2(
-            _("Password Missmatch"), _("Password must not be empty."),
+            _("Password Mismatch"), _("Password must not be empty."),
             _("Do you want to retry?"), YACURS::YESNO);
         nomatchdialog->show();
         return false;


### PR DESCRIPTION
In the binary and the pot/po files there were some occurences of the
word "Missmatch" which should be "Mismatch" accordingly.

This was spotted by lintian, the "Debian package checker" which dissects
Debian packages and reports bugs and policy violations.

https://lintian.debian.org/tags/spelling-error-in-binary.html