### PR TITLE
Make yapet work again openssl 3.0.13 and later

### DIFF
--- a/src/libs/crypt/aes256.cc
+++ b/src/libs/crypt/aes256.cc
@@ -113,17 +113,6 @@ EVP_CIPHER_CTX* Aes256::initializeOrThrow(const SecureArray& ivec, MODE mode) {
         throw CipherError{_("Error initializing cipher")};
     }
 
-    success = EVP_CIPHER_CTX_set_key_length(context, getKey()->keySize());
-    if (success != SSL_SUCCESS) {
-        LOG_MESSAGE(std::string{__func__} + ": Error setting key length");
-        destroyContext(context);
-        char msg[YAPET::Consts::EXCEPTION_MESSAGE_BUFFER_SIZE];
-        std::snprintf(msg, YAPET::Consts::EXCEPTION_MESSAGE_BUFFER_SIZE,
-                      _("Cannot set key length on context to %d"),
-                      getKey()->keySize());
-        throw CipherError{msg};
-    }
-
     return context;
 }
 

--- a/src/libs/crypt/crypto.cc
+++ b/src/libs/crypt/crypto.cc
@@ -98,16 +98,6 @@ EVP_CIPHER_CTX* Crypto::initializeOrThrow(MODE mode) {
         throw CipherError{_("Error initializing cipher")};
     }
 
-    success = EVP_CIPHER_CTX_set_key_length(context, _key->keySize());
-    if (success != SSL_SUCCESS) {
-        destroyContext(context);
-        char msg[YAPET::Consts::EXCEPTION_MESSAGE_BUFFER_SIZE];
-        std::snprintf(msg, YAPET::Consts::EXCEPTION_MESSAGE_BUFFER_SIZE,
-                      _("Cannot set key length on context to %d"),
-                      _key->keySize());
-        throw CipherError{msg};
-    }
-
     return context;
 }
 


### PR DESCRIPTION
OpenSSL 3.0.13 added stricted error checking which revealed an error in the blowfish implementation with yapet.
The blowfish bits are needed to get everything to work. The aes bits are cosmetic (their order it wrong and a nop).

I suggest to add a big banner to motivate people to migrate away from the blowfish database towards the aes one.

Sebastian